### PR TITLE
Fix errors in docker and ParcelShopService

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM maven:3.8.5-openjdk-17
 # FROM maven:3.8.2-jdk-8 # for Java 8
 
 WORKDIR /acme-api-consumer
-COPY acme-api-consumer .
-RUN mvn clean install
+COPY . .
+RUN mvn clean install -DskipTests
 
 CMD mvn spring-boot:run

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,10 +1,12 @@
 version: "3.8"
 services:
   acme-api-consumer:
-    build: acme-api-consumer
+    build: .
     container_name: "docker-app"
     ports:
       - 8080:8080
+    depends_on:
+      - mongodb
   mongodb:
     image: mongo:latest
     container_name: "mongodb"

--- a/src/main/java/com/acme/AcmeApiConsumerApplication.java
+++ b/src/main/java/com/acme/AcmeApiConsumerApplication.java
@@ -1,7 +1,6 @@
 package com.acme;
 
 import com.acme.getparcelshops.ParcelShopService;
-import com.acme.login.LoginRepository;
 import com.acme.login.LoginService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
@@ -16,8 +15,6 @@ public class AcmeApiConsumerApplication {
 	public LoginService loginService;
 	@Autowired
 	public ParcelShopService parcelShopService;
-	@Autowired
-	public LoginRepository loginRepository;
 
 	public static void main(String[] args) {
 		SpringApplication.run(AcmeApiConsumerApplication.class, args);
@@ -26,11 +23,8 @@ public class AcmeApiConsumerApplication {
 	@Bean
 	public CommandLineRunner commandLineRunner() {
 		return args -> {
-			// Call the login service to perform login
-			loginService.saveLogin();
-			var token = loginRepository.findByUsername("assignment-test@ubsend.com").getAccessToken();
+			String token = loginService.saveLogin();
 			parcelShopService.saveParcelShops(token);
 		};
 	}
-
 }

--- a/src/main/java/com/acme/Config.java
+++ b/src/main/java/com/acme/Config.java
@@ -1,5 +1,7 @@
 package com.acme;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
@@ -8,7 +10,11 @@ import org.springframework.web.client.RestTemplate;
 public class Config {
 
     @Bean
-    public RestTemplate restTemplate() {
-        return new RestTemplate();
+    public RestTemplate loginApi(RestTemplateBuilder builder, @Value("${login.api.url}") String path) {
+        return builder.rootUri(path).build();
+    }
+    @Bean
+    public RestTemplate parcelApi(RestTemplateBuilder builder, @Value("${getparcelshop.api.url}") String path) {
+        return builder.rootUri(path).build();
     }
 }

--- a/src/main/java/com/acme/getparcelshops/ParcelShopRepository.java
+++ b/src/main/java/com/acme/getparcelshops/ParcelShopRepository.java
@@ -2,5 +2,5 @@ package com.acme.getparcelshops;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface ParcelShopRepository extends MongoRepository<ParcelShopResponse, ParcelShopResponse> {
+public interface ParcelShopRepository extends MongoRepository<ParcelShop, String> {
 }

--- a/src/main/java/com/acme/getparcelshops/ParcelShopService.java
+++ b/src/main/java/com/acme/getparcelshops/ParcelShopService.java
@@ -2,32 +2,47 @@ package com.acme.getparcelshops;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.List;
 
 @Slf4j
 @Service
 public class ParcelShopService {
+    private final ParcelShopRepository parcelShopRepository;
+    private final RestTemplate parcelApi;
 
     @Autowired
-    private ParcelShopRepository parcelShopRepository;
-    @Autowired
-    private final RestTemplate restTemplate = new RestTemplate();
-
-    @Value("${getparcelshop.api.url}")
-    private String baseUrl;
-
-    public ParcelShopResponse getParcelShops(@RequestHeader("Authorization") String token, @RequestParam(name = "carrier") String carrier, @RequestParam(name = "country") String country, @RequestParam(name = "limit") String limit) {
-        return restTemplate.getForObject(baseUrl, ParcelShopResponse.class, token, carrier, country, limit);
+    public ParcelShopService(ParcelShopRepository parcelShopRepository, RestTemplate parcelApi) {
+        this.parcelShopRepository = parcelShopRepository;
+        this.parcelApi = parcelApi;
     }
 
-    public void saveParcelShops(@RequestHeader("Authorization") String token) {
+    public List<ParcelShop> getParcelShops(String token, String carrier, String country, String limit) {
+        String urlTemplate = UriComponentsBuilder.fromPath("/parcel-shops")
+                .queryParam("carrier", carrier)
+                .queryParam("country", country)
+                .queryParam("limit", limit)
+                .toUriString();
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setBearerAuth(token);
+        return parcelApi.exchange(urlTemplate,
+                HttpMethod.GET,
+                new HttpEntity<>(httpHeaders),
+                new ParameterizedTypeReference<List<ParcelShop>>() {
+        }).getBody();
+    }
+
+    public void saveParcelShops(String token) {
         try {
             var response = getParcelShops(token, "CORREOS", "ES", "10");
-            parcelShopRepository.save(response);
+            parcelShopRepository.saveAll(response);
         } catch (Exception e) {
             log.error("Error while saving parcel shops: {}", e.getMessage());
         }

--- a/src/main/java/com/acme/login/LoginService.java
+++ b/src/main/java/com/acme/login/LoginService.java
@@ -2,7 +2,6 @@ package com.acme.login;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.client.RestTemplate;
@@ -10,28 +9,32 @@ import org.springframework.web.client.RestTemplate;
 @Slf4j
 @Service
 public class LoginService {
+    public final LoginRepository loginRepository;
+    private final RestTemplate loginApi;
+    public static final String USERNAME = "assignment-test@ubsend.com";
+    public static final String PASSWORD = "p0DrmE)E+BQH$]KasMSb";
 
     @Autowired
-    public LoginRepository loginRepository;
-    @Autowired
-    private final RestTemplate restTemplate = new RestTemplate();
-
-    @Value("${login.api.url}")
-    private String baseUrl;
-
-    public LoginResponse getLogin(@RequestBody LoginRequest loginRequest) {
-        return restTemplate.postForObject(baseUrl, loginRequest, LoginResponse.class);
+    public LoginService(LoginRepository loginRepository, RestTemplate loginApi) {
+        this.loginRepository = loginRepository;
+        this.loginApi = loginApi;
     }
 
-    public void saveLogin() {
+    public LoginResponse getLogin(@RequestBody LoginRequest loginRequest) {
+        return loginApi.postForObject("/login", loginRequest, LoginResponse.class);
+    }
+
+    public String saveLogin() {
         try {
             var response = getLogin(LoginRequest.builder()
-                    .username("assignment-test@ubsend.com")
-                    .password("p0DrmE)E+BQH$]KasMSb")
+                    .username(USERNAME)
+                    .password(PASSWORD)
                     .build());
             loginRepository.save(response);
+            return response.getAccessToken();
         } catch (Exception e) {
             log.error("Error while saving login response: {}", e.getMessage());
+            return "Error";
         }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,10 @@
 spring.application.name=ACME API consumer
-login.api.url=https://staging-api.ubsend.io/v1/auth/login
-getparcelshop.api.url=https://staging-api.ubsend.io/v1/parcel-shops/parcel-shops?radius=100000
+login.api.url=https://staging-api.ubsend.io/v1/auth
+getparcelshop.api.url=https://staging-api.ubsend.io/v1/parcel-shops
 
 server.port=8000
-spring.data.mongodb.host=localhost
-spring.data.mongodb.port=27070
+spring.data.mongodb.host=mongodb
+spring.data.mongodb.port=27017
 spring.data.mongodb.database=docker-db
+
+logging.level.root=INFO


### PR DESCRIPTION
Set up correct docker to connect to mongoDB.
Make ParcelShopService not be dependent on data from database.

Utilize ParcelShop entity as a response when calling the parcelshop endpoint. Use the exchange resttemplate for the get endpoint in order to use queryparams.

Remove hardcoded values, and make them static attributes.